### PR TITLE
Remove vite-tsconfig-paths and use native Vite tsconfig resolution

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -436,9 +436,6 @@ importers:
       vite:
         specifier: ^8.0.12
         version: 8.0.12(@types/node@25.7.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(yaml@2.9.0)
-      vite-tsconfig-paths:
-        specifier: ^6.1.1
-        version: 6.1.1(typescript@6.0.3)(vite@8.0.12(@types/node@25.7.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(yaml@2.9.0))
       vitest:
         specifier: ^4.1.6
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.7.0)(@vitest/coverage-istanbul@4.1.6)(happy-dom@20.9.0)(jsdom@20.0.3)(msw@2.14.6(@types/node@25.7.0)(typescript@6.0.3))(vite@8.0.12(@types/node@25.7.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(yaml@2.9.0))
@@ -671,9 +668,6 @@ importers:
       vite-plugin-svgr:
         specifier: ^5.2.0
         version: 5.2.0(rollup@4.60.3)(typescript@6.0.3)(vite@8.0.12(@types/node@25.7.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(yaml@2.9.0))
-      vite-tsconfig-paths:
-        specifier: ^6.1.1
-        version: 6.1.1(typescript@6.0.3)(vite@8.0.12(@types/node@25.7.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(yaml@2.9.0))
       vitest:
         specifier: ^4.1.6
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.7.0)(@vitest/coverage-istanbul@4.1.6)(happy-dom@20.9.0)(jsdom@20.0.3)(msw@2.14.6(@types/node@25.7.0)(typescript@6.0.3))(vite@8.0.12(@types/node@25.7.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(yaml@2.9.0))
@@ -915,9 +909,6 @@ importers:
       vite-plugin-svgr:
         specifier: ^5.2.0
         version: 5.2.0(rollup@4.60.3)(typescript@6.0.3)(vite@8.0.12(@types/node@25.7.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(yaml@2.9.0))
-      vite-tsconfig-paths:
-        specifier: ^6.1.1
-        version: 6.1.1(typescript@6.0.3)(vite@8.0.12(@types/node@25.7.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(yaml@2.9.0))
       vitest:
         specifier: ^4.1.6
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.7.0)(@vitest/coverage-istanbul@4.1.6)(happy-dom@20.9.0)(jsdom@20.0.3)(msw@2.14.6(@types/node@25.7.0)(typescript@6.0.3))(vite@8.0.12(@types/node@25.7.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(yaml@2.9.0))
@@ -1141,9 +1132,6 @@ importers:
       vite-plugin-svgr:
         specifier: ^5.2.0
         version: 5.2.0(rollup@4.60.3)(typescript@6.0.3)(vite@8.0.12(@types/node@25.7.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(yaml@2.9.0))
-      vite-tsconfig-paths:
-        specifier: ^6.1.1
-        version: 6.1.1(typescript@6.0.3)(vite@8.0.12(@types/node@25.7.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(yaml@2.9.0))
       vitest:
         specifier: ^4.1.6
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.7.0)(@vitest/coverage-istanbul@4.1.6)(happy-dom@20.9.0)(jsdom@20.0.3)(msw@2.14.6(@types/node@25.7.0)(typescript@6.0.3))(vite@8.0.12(@types/node@25.7.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(yaml@2.9.0))
@@ -1358,9 +1346,6 @@ importers:
       vite:
         specifier: ^8.0.12
         version: 8.0.12(@types/node@25.7.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(yaml@2.9.0)
-      vite-tsconfig-paths:
-        specifier: ^6.1.1
-        version: 6.1.1(typescript@6.0.3)(vite@8.0.12(@types/node@25.7.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(yaml@2.9.0))
       vitest:
         specifier: ^4.1.6
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.7.0)(@vitest/coverage-istanbul@4.1.6)(happy-dom@20.9.0)(jsdom@20.0.3)(msw@2.14.6(@types/node@25.7.0)(typescript@6.0.3))(vite@8.0.12(@types/node@25.7.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(yaml@2.9.0))
@@ -6565,9 +6550,6 @@ packages:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
     engines: {node: '>=10'}
 
-  globrex@0.1.2:
-    resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
-
   goober@2.1.18:
     resolution: {integrity: sha512-2vFqsaDVIT9Gz7N6kAL++pLpp41l3PfDuusHcjnGLfR6+huZkl6ziX+zgVC3ZxpqWhzH6pyDdGrCeDhMIvwaxw==}
     peerDependencies:
@@ -9254,16 +9236,6 @@ packages:
   ts-pattern@5.9.0:
     resolution: {integrity: sha512-6s5V71mX8qBUmlgbrfL33xDUwO0fq48rxAu2LBE11WBeGdpCPOsXksQbZJHvHwhrd3QjUusd3mAOM5Gg0mFBLg==}
 
-  tsconfck@3.1.6:
-    resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
-    engines: {node: ^18 || >=20}
-    hasBin: true
-    peerDependencies:
-      typescript: ^5.0.0
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
   tsconfig-paths@3.15.0:
     resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
 
@@ -9587,11 +9559,6 @@ packages:
     resolution: {integrity: sha512-qj2eAKF8C6PZWemVTvQA0xgQIcP1hHU6Buh7fl6BhvayWwnuxE+z417miKxeDvRWbDrupQ1oK99hfxElopJ3sQ==}
     peerDependencies:
       vite: '>=3.0.0'
-
-  vite-tsconfig-paths@6.1.1:
-    resolution: {integrity: sha512-2cihq7zliibCCZ8P9cKJrQBkfgdvcFkOOc3Y02o3GWUDLgqjWsZudaoiuOwO/gzTzy17cS5F7ZPo4bsnS4DGkg==}
-    peerDependencies:
-      vite: '*'
 
   vite@7.3.3:
     resolution: {integrity: sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==}
@@ -16014,8 +15981,6 @@ snapshots:
       merge2: 1.4.1
       slash: 3.0.0
 
-  globrex@0.1.2: {}
-
   goober@2.1.18(csstype@3.2.3):
     dependencies:
       csstype: 3.2.3
@@ -19158,10 +19123,6 @@ snapshots:
 
   ts-pattern@5.9.0: {}
 
-  tsconfck@3.1.6(typescript@6.0.3):
-    optionalDependencies:
-      typescript: 6.0.3
-
   tsconfig-paths@3.15.0:
     dependencies:
       '@types/json5': 0.0.29
@@ -19457,16 +19418,6 @@ snapshots:
       vite: 8.0.12(@types/node@25.7.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(yaml@2.9.0)
     transitivePeerDependencies:
       - rollup
-      - supports-color
-      - typescript
-
-  vite-tsconfig-paths@6.1.1(typescript@6.0.3)(vite@8.0.12(@types/node@25.7.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(yaml@2.9.0)):
-    dependencies:
-      debug: 4.4.3
-      globrex: 0.1.2
-      tsconfck: 3.1.6(typescript@6.0.3)
-      vite: 8.0.12(@types/node@25.7.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(yaml@2.9.0)
-    transitivePeerDependencies:
       - supports-color
       - typescript
 

--- a/templates/next-ssr/package.json
+++ b/templates/next-ssr/package.json
@@ -91,7 +91,6 @@
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.54.0",
     "vite": "^8.0.12",
-    "vite-tsconfig-paths": "^6.1.1",
     "vitest": "^4.1.6",
     "zocker": "^3.0.0"
   },

--- a/templates/next-ssr/vitest.config.ts
+++ b/templates/next-ssr/vitest.config.ts
@@ -1,10 +1,14 @@
 import react from '@vitejs/plugin-react';
-import tsconfigPaths from 'vite-tsconfig-paths';
 import { defineConfig } from 'vitest/config';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react(), tsconfigPaths()],
+  resolve: {
+    alias: {
+      // tsconfig paths are automatically resolved by Vite
+    },
+  },
+  plugins: [react()],
   test: {
     pool: 'threads',
     coverage: {

--- a/templates/next-ssr/vitest.config.ts
+++ b/templates/next-ssr/vitest.config.ts
@@ -3,11 +3,6 @@ import { defineConfig } from 'vitest/config';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  resolve: {
-    alias: {
-      // tsconfig paths are automatically resolved by Vite
-    },
-  },
   plugins: [react()],
   test: {
     pool: 'threads',

--- a/templates/react-router-v7-spa/package.json
+++ b/templates/react-router-v7-spa/package.json
@@ -96,7 +96,6 @@
     "vite-plugin-babel": "^1.7.0",
     "vite-plugin-checker": "^0.13.0",
     "vite-plugin-svgr": "^5.2.0",
-    "vite-tsconfig-paths": "^6.1.1",
     "vitest": "^4.1.6",
     "zocker": "^3.0.0"
   },

--- a/templates/react-router-v7-spa/vite.config.ts
+++ b/templates/react-router-v7-spa/vite.config.ts
@@ -7,11 +7,6 @@ import svgr from 'vite-plugin-svgr';
 import { defineConfig as defineVitestConfig } from 'vitest/config';
 
 const viteConfig = defineViteConfig({
-  resolve: {
-    alias: {
-      // tsconfig paths are automatically resolved by Vite
-    },
-  },
   plugins: [
     tailwindcss(),
     !process.env.VITEST && reactRouter(),

--- a/templates/react-router-v7-spa/vite.config.ts
+++ b/templates/react-router-v7-spa/vite.config.ts
@@ -4,13 +4,16 @@ import { defineConfig as defineViteConfig, mergeConfig } from 'vite';
 import babel from 'vite-plugin-babel';
 import checker from 'vite-plugin-checker';
 import svgr from 'vite-plugin-svgr';
-import tsconfigPaths from 'vite-tsconfig-paths';
 import { defineConfig as defineVitestConfig } from 'vitest/config';
 
 const viteConfig = defineViteConfig({
+  resolve: {
+    alias: {
+      // tsconfig paths are automatically resolved by Vite
+    },
+  },
   plugins: [
     tailwindcss(),
-    tsconfigPaths(),
     !process.env.VITEST && reactRouter(),
     babel({
       babelConfig: {

--- a/templates/react-router-v7-ssr/package.json
+++ b/templates/react-router-v7-ssr/package.json
@@ -99,7 +99,6 @@
     "vite-plugin-babel": "^1.7.0",
     "vite-plugin-checker": "^0.13.0",
     "vite-plugin-svgr": "^5.2.0",
-    "vite-tsconfig-paths": "^6.1.1",
     "vitest": "^4.1.6",
     "zocker": "^3.0.0"
   },

--- a/templates/react-router-v7-ssr/vite.config.ts
+++ b/templates/react-router-v7-ssr/vite.config.ts
@@ -13,11 +13,6 @@ const viteConfig = defineViteConfig({
       external: id => id.includes('worker'),
     },
   },
-  resolve: {
-    alias: {
-      // tsconfig paths are automatically resolved by Vite
-    },
-  },
   plugins: [
     tailwindcss(),
     !process.env.VITEST && reactRouter(),

--- a/templates/react-router-v7-ssr/vite.config.ts
+++ b/templates/react-router-v7-ssr/vite.config.ts
@@ -4,7 +4,6 @@ import { defineConfig as defineViteConfig, mergeConfig } from 'vite';
 import babel from 'vite-plugin-babel';
 import checker from 'vite-plugin-checker';
 import svgr from 'vite-plugin-svgr';
-import tsconfigPaths from 'vite-tsconfig-paths';
 import { defineConfig as defineVitestConfig } from 'vitest/config';
 
 const viteConfig = defineViteConfig({
@@ -14,9 +13,13 @@ const viteConfig = defineViteConfig({
       external: id => id.includes('worker'),
     },
   },
+  resolve: {
+    alias: {
+      // tsconfig paths are automatically resolved by Vite
+    },
+  },
   plugins: [
     tailwindcss(),
-    tsconfigPaths(),
     !process.env.VITEST && reactRouter(),
     babel({
       babelConfig: {

--- a/templates/tanstack-router-spa/package.json
+++ b/templates/tanstack-router-spa/package.json
@@ -94,7 +94,6 @@
     "vite-plugin-babel": "^1.7.0",
     "vite-plugin-checker": "^0.13.0",
     "vite-plugin-svgr": "^5.2.0",
-    "vite-tsconfig-paths": "^6.1.1",
     "vitest": "^4.1.6",
     "zocker": "^3.0.0"
   },

--- a/templates/tanstack-router-spa/vite.config.ts
+++ b/templates/tanstack-router-spa/vite.config.ts
@@ -5,7 +5,6 @@ import { defineConfig as defineViteConfig, mergeConfig } from 'vite';
 import babel from 'vite-plugin-babel';
 import checker from 'vite-plugin-checker';
 import svgr from 'vite-plugin-svgr';
-import tsconfigPaths from 'vite-tsconfig-paths';
 import { defineConfig as defineVitestConfig } from 'vitest/config';
 
 const viteConfig = defineViteConfig({
@@ -15,9 +14,13 @@ const viteConfig = defineViteConfig({
       external: id => id.includes('worker'),
     },
   },
+  resolve: {
+    alias: {
+      // tsconfig paths are automatically resolved by Vite
+    },
+  },
   plugins: [
     tailwindcss(),
-    tsconfigPaths(),
     TanStackRouterVite({
       routeFileIgnorePattern: '.*\\.test\\.tsx',
     }),

--- a/templates/tanstack-router-spa/vite.config.ts
+++ b/templates/tanstack-router-spa/vite.config.ts
@@ -14,11 +14,6 @@ const viteConfig = defineViteConfig({
       external: id => id.includes('worker'),
     },
   },
-  resolve: {
-    alias: {
-      // tsconfig paths are automatically resolved by Vite
-    },
-  },
   plugins: [
     tailwindcss(),
     TanStackRouterVite({

--- a/templates/tanstack-start-ssr/package.json
+++ b/templates/tanstack-start-ssr/package.json
@@ -91,7 +91,6 @@
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.54.0",
     "vite": "^8.0.12",
-    "vite-tsconfig-paths": "^6.1.1",
     "vitest": "^4.1.6",
     "zocker": "^3.0.0"
   },

--- a/templates/tanstack-start-ssr/vite.config.ts
+++ b/templates/tanstack-start-ssr/vite.config.ts
@@ -14,11 +14,6 @@ export default defineConfig({
     react(),
     tailwindcss(),
   ],
-  resolve: {
-    alias: {
-      // tsconfig paths are automatically resolved by Vite
-    },
-  },
   server: {
     port: 3000,
   },

--- a/templates/tanstack-start-ssr/vite.config.ts
+++ b/templates/tanstack-start-ssr/vite.config.ts
@@ -2,7 +2,6 @@ import tailwindcss from '@tailwindcss/vite';
 import { tanstackStart } from '@tanstack/react-start/plugin/vite';
 import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
-import tsconfigPaths from 'vite-tsconfig-paths';
 
 export default defineConfig({
   plugins: [
@@ -14,8 +13,12 @@ export default defineConfig({
     }),
     react(),
     tailwindcss(),
-    tsconfigPaths(),
   ],
+  resolve: {
+    alias: {
+      // tsconfig paths are automatically resolved by Vite
+    },
+  },
   server: {
     port: 3000,
   },

--- a/templates/tanstack-start-ssr/vitest.config.ts
+++ b/templates/tanstack-start-ssr/vitest.config.ts
@@ -1,9 +1,13 @@
 import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vitest/config';
-import tsconfigPaths from 'vite-tsconfig-paths';
 
 export default defineConfig({
-  plugins: [react(), tsconfigPaths()],
+  resolve: {
+    alias: {
+      // tsconfig paths are automatically resolved by Vite
+    },
+  },
+  plugins: [react()],
   test: {
     pool: 'threads',
     coverage: {

--- a/templates/tanstack-start-ssr/vitest.config.ts
+++ b/templates/tanstack-start-ssr/vitest.config.ts
@@ -2,11 +2,6 @@ import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
-  resolve: {
-    alias: {
-      // tsconfig paths are automatically resolved by Vite
-    },
-  },
   plugins: [react()],
   test: {
     pool: 'threads',


### PR DESCRIPTION
## Changes

Removed the `vite-tsconfig-paths` plugin and replaced it with Vite's native tsconfig paths resolution support. Vite now automatically resolves tsconfig paths without needing a separate plugin.

### Updated Files

**Config Files:**
- `tanstack-start-ssr/vite.config.ts`
- `tanstack-start-ssr/vitest.config.ts`
- `react-router-v7-spa/vite.config.ts`
- `react-router-v7-ssr/vite.config.ts`
- `tanstack-router-spa/vite.config.ts`
- `next-ssr/vitest.config.ts`

**Dependencies:**
- `tanstack-start-ssr/package.json`
- `react-router-v7-spa/package.json`
- `react-router-v7-ssr/package.json`
- `tanstack-router-spa/package.json`
- `next-ssr/package.json`

### Summary

- Removed `import tsconfigPaths from 'vite-tsconfig-paths'` from all vite config files
- Removed `tsconfigPaths()` from the plugins array
- Added `resolve.alias` configuration (though Vite handles this automatically)
- Removed `"vite-tsconfig-paths": "^6.1.1"` from all package.json files