### PR TITLE
chore: fix docs and skills manifest drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ These templates are meant to be a starting point for new projects and are not me
 This repository includes **14 standardized agent skills** compatible with GitHub Copilot, Claude Code, Cursor, and 20+ other AI coding agents. These skills provide specialized expertise for:
 
 - **8 SDLC Phase Skills**: Requirements analysis, architecture, implementation, UI/UX, testing, deployment, maintenance, and production support
-- **6 Template-Specific Skills**: TypeScript libraries, Next.js SSR, React Router (SPA & SSR), TanStack Router, and Expo React Native
+- **7 Template-Specific Skills**: TypeScript libraries, Next.js SSR, React Router (SPA & SSR), TanStack Router, TanStack Start SSR, and Expo React Native
 
 **Quick Install:**
 ```bash

--- a/skills-manifest.json
+++ b/skills-manifest.json
@@ -176,6 +176,32 @@
           }
         ]
       },
+      "tanstack-start-ssr": {
+        "description": "TanStack Start SSR with full-stack routing and server functions",
+        "tooling": ["tanstack-start", "tanstack-router", "vite", "vitest", "playwright", "typescript", "tailwind-css", "react-hook-form", "zod", "tanstack-query", "node-ssr"],
+        "skills": [
+          {
+            "name": "tanstack-router-best-practices",
+            "repo": "deckardger/tanstack-agent-skills",
+            "reason": "TanStack Router and Start patterns for type-safe full-stack routing"
+          },
+          {
+            "name": "epic-react-patterns",
+            "repo": "epicweb-dev/epic-stack",
+            "reason": "Advanced React composition and data flow patterns for SSR"
+          },
+          {
+            "name": "find-skills",
+            "repo": "vercel-labs/skills",
+            "reason": "Discover additional ecosystem skills for evolving template needs"
+          },
+          {
+            "name": "skill-creator",
+            "repo": "anthropics/skills",
+            "reason": "Create template-specific skills and customization workflows"
+          }
+        ]
+      },
       "typescript-library": {
         "description": "Pure TypeScript library with tsdown, ESM/CJS exports, and Changesets",
         "tooling": ["tsdown", "typescript", "vitest", "changesets", "npm-publishing", "esm-cjs"],
@@ -292,6 +318,17 @@
           "cd templates/tanstack-router-spa",
           "npx -y skills add deckardger/tanstack-agent-skills --skill tanstack-router-best-practices --agent claude-code cursor",
           "npx -y skills add manutej/luxor-claude-marketplace --skill jest-react-testing --agent claude-code cursor",
+          "npx -y skills add vercel-labs/skills --skill find-skills --agent claude-code cursor",
+          "npx -y skills add anthropics/skills --skill skill-creator --agent claude-code cursor",
+          "EXCLUDE: Vue/Nuxt skills (React-only template)"
+        ]
+      },
+      "tanstack-start-ssr": {
+        "instructions": "TanStack Start SSR with full-stack routing",
+        "commands": [
+          "cd templates/tanstack-start-ssr",
+          "npx -y skills add deckardger/tanstack-agent-skills --skill tanstack-router-best-practices --agent claude-code cursor",
+          "npx -y skills add epicweb-dev/epic-stack --skill epic-react-patterns --agent claude-code cursor",
           "npx -y skills add vercel-labs/skills --skill find-skills --agent claude-code cursor",
           "npx -y skills add anthropics/skills --skill skill-creator --agent claude-code cursor",
           "EXCLUDE: Vue/Nuxt skills (React-only template)"

--- a/templates/next-ssr/.github/actions/setup-pull-request-job/action.yml
+++ b/templates/next-ssr/.github/actions/setup-pull-request-job/action.yml
@@ -1,4 +1,5 @@
 name: Pull Request
+description: Setup pull request jobs for Next.js template
 
 runs:
   using: 'composite'
@@ -16,7 +17,7 @@ runs:
       shell: bash
       run: |
         touch .env
-        echo "NEXT_APP_ENVIRONMENT=dev" >> .env
+        echo "NEXT_PUBLIC_APP_ENVIRONMENT=dev" >> .env
     - name: Install Dependencies
       shell: bash
       run: pnpm install --frozen-lockfile

--- a/templates/next-ssr/README.md
+++ b/templates/next-ssr/README.md
@@ -1,10 +1,10 @@
 # Next SSR Template
 
-A modern, production-ready template for building server-side rendered applications with Next.js 15, featuring React 19, React Compiler, type-safe i18n, comprehensive testing, and excellent developer experience.
+A modern, production-ready template for building server-side rendered applications with Next.js 16, featuring React 19, React Compiler, type-safe i18n, comprehensive testing, and excellent developer experience.
 
 ## ✨ Features
 
-- **🚀 Next.js 15** - Latest Next.js with App Router, Server Components, and RSC patterns
+- **🚀 Next.js 16** - Latest Next.js with App Router, Server Components, and RSC patterns
 - **⚛️ React 19** - Latest React with React Compiler for automatic optimizations
 - **⚡ Turbopack** - Ultra-fast bundler for lightning-quick development
 - **🌍 Internationalization** - Type-safe i18n with `useAppTranslation` hook and mandatory translations

--- a/templates/tanstack-router-spa/README.md
+++ b/templates/tanstack-router-spa/README.md
@@ -91,7 +91,7 @@ pnpm dev
 | ------------ | ------------------------ |
 | `pnpm dev`   | Start development server |
 | `pnpm build` | Build for production     |
-| `pnpm serve` | Preview production build |
+| `pnpm start` | Preview production build |
 
 ### Testing & Quality
 
@@ -231,7 +231,7 @@ src/routes/
 pnpm build
 
 # Preview the build locally
-pnpm serve
+pnpm start
 ```
 
 The build is optimized for:


### PR DESCRIPTION
## Summary\n- update root README template skill count to include TanStack Start SSR\n- align Next SSR README to Next.js 16\n- fix Next SSR PR setup action env var to NEXT_PUBLIC_APP_ENVIRONMENT\n- fix TanStack Router SPA README preview script from serve to start\n- add tanstack-start-ssr entries to skills-manifest template mappings and install commands\n\n## Why\nThese changes remove config/documentation drift and keep template metadata aligned with actual template inventory and runtime env contracts.\n\n## Validation\n- parsed skills-manifest.json successfully\n- checked modified files for diagnostics